### PR TITLE
Fix oreBasalticMineralSand properly being mapped to "ore" prefix, ins…

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -795,6 +795,7 @@ public enum OrePrefixes {
         for (OrePrefixes tPrefix : values())
             if (aOre.startsWith(tPrefix.toString())) {
                 if (tPrefix == oreNether && aOre.equals("oreNetherQuartz")) return ore;
+                if (tPrefix == oreBasalt && aOre.equals("oreBasalticMineralSand")) return ore;
                 return tPrefix;
             }
         return null;


### PR DESCRIPTION
…tead of the "oreBasalt" prefix, yielding the wrong material "icMineralsand"